### PR TITLE
Fix import d3 error

### DIFF
--- a/src/lasso.js
+++ b/src/lasso.js
@@ -44,7 +44,7 @@ export default function() {
         var drawnCoords;
 
          // Apply drag behaviors
-        var drag = d3.drag()
+        var drag = drag()
             .on("start",dragstart)
             .on("drag",dragmove)
             .on("end",dragend);
@@ -87,19 +87,19 @@ export default function() {
         function dragmove() {
             // Get mouse position within body, used for calculations
             var x,y;
-            if(d3.event.sourceEvent.type === "touchmove") {
-                x = d3.event.sourceEvent.touches[0].clientX;
-                y = d3.event.sourceEvent.touches[0].clientY;
+            if(event.sourceEvent.type === "touchmove") {
+                x = event.sourceEvent.touches[0].clientX;
+                y = event.sourceEvent.touches[0].clientY;
             }
             else {
-                x = d3.event.sourceEvent.clientX;
-                y = d3.event.sourceEvent.clientY;
+                x = event.sourceEvent.clientX;
+                y = event.sourceEvent.clientY;
             }
             
 
             // Get mouse position within drawing area, used for rendering
-            var tx = d3.mouse(this)[0];
-            var ty = d3.mouse(this)[1];
+            var tx = mouse(this)[0];
+            var ty = mouse(this)[1];
 
             // Initialize the path or add the latest point to it
             if (tpath==="") {

--- a/src/lasso.js
+++ b/src/lasso.js
@@ -44,13 +44,13 @@ export default function() {
         var drawnCoords;
 
          // Apply drag behaviors
-        var drag = drag()
+        var dragAction = drag()
             .on("start",dragstart)
             .on("drag",dragmove)
             .on("end",dragend);
 
         // Call drag
-        targetArea.call(drag);
+        targetArea.call(dragAction);
 
         function dragstart() {
             // Init coordinates

--- a/src/lasso.js
+++ b/src/lasso.js
@@ -44,7 +44,7 @@ export default function() {
         var drawnCoords;
 
          // Apply drag behaviors
-        var dragAction = drag()
+        var dragAction = drag.drag()
             .on("start",dragstart)
             .on("drag",dragmove)
             .on("end",dragend);
@@ -87,19 +87,19 @@ export default function() {
         function dragmove() {
             // Get mouse position within body, used for calculations
             var x,y;
-            if(event.sourceEvent.type === "touchmove") {
-                x = event.sourceEvent.touches[0].clientX;
-                y = event.sourceEvent.touches[0].clientY;
+            if(selection.event.sourceEvent.type === "touchmove") {
+                x = selection.event.sourceEvent.touches[0].clientX;
+                y = selection.event.sourceEvent.touches[0].clientY;
             }
             else {
-                x = event.sourceEvent.clientX;
-                y = event.sourceEvent.clientY;
+                x = selection.event.sourceEvent.clientX;
+                y = selection.event.sourceEvent.clientY;
             }
             
 
             // Get mouse position within drawing area, used for rendering
-            var tx = mouse(this)[0];
-            var ty = mouse(this)[1];
+            var tx = selection.mouse(this)[0];
+            var ty = selection.mouse(this)[1];
 
             // Initialize the path or add the latest point to it
             if (tpath==="") {


### PR DESCRIPTION
src/lasso.js updated to use imported libs (d3-selection and d3-drag) instead of d3 library. This way it is possible to use d3-lasso in a d3 modules based project without the need of installing the whole d3 library.