### PR TITLE
Added synthetic mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,22 @@ The hoverSelect() parameter takes in a boolean that determines whether objects c
 lasso.hoverSelect(true); // allows hovering of elements for selection during lassoing
 ```
 
+lasso.**synthetic**(_[bool]_)
+
+TRY IT HERE: https://lasso-synthetic.stackblitz.io/
+
+The synthetic paramater takes in a boolean that determins whether the events will be rendered in the DOM (traditional lasso) or whether they are simply provided as Objects. This is to support scenarios like lasso-ing over a density map that contains way too many points to render in the DOM.
+Each point is expected to have at least the following signature:
+``` 
+{
+    x: number;
+    y: number;
+}
+```
+although it's strongly recommended to provide an id to later reconcile the lasso-ed items with the items in the application.
+
+Note that, if synthetic mode is needed, it is necessary that is set before providing the items.
+
 lasso.**closePathSelect**(_[bool]_)
 
 The closePathSelect() parameter takes in a boolean that determines whether objects can be lassoed by drawing a loop around them. The default value is set to true. If no input is specified, the function returns the lasso's current parameter.
@@ -89,6 +105,15 @@ The on() parameter takes in a type of event and a function for that event. There
 - start: this function will be executed whenever a lasso is started
 - draw: this function will execute repeatedly as the lasso is drawn
 - end: this function will be executed whenever a lasso is completed
+- clear: this function will be executed after a lasso is completed, by default it clears the lasso shape. It is invoked with three arguments:
+    
+    `dyn_path`: drawn path
+
+    `close_path`: auto-closing path if present
+
+    `origin_node`: node that identifies the location of lasso start
+
+
 
 If no function is specified, the function will return the current function defined for the type specified.
 ```

--- a/src/lasso.js
+++ b/src/lasso.js
@@ -104,17 +104,17 @@ export default function () {
         function dragmove() {
             // Get mouse position within body, used for calculations
             var x, y;
-            if (d3.event.sourceEvent.type === "touchmove") {
-                x = d3.event.sourceEvent.touches[0].clientX;
-                y = d3.event.sourceEvent.touches[0].clientY;
+            if (selection.event.sourceEvent.type === "touchmove") {
+                x = selection.event.sourceEvent.touches[0].clientX;
+                y = selection.event.sourceEvent.touches[0].clientY;
             } else {
-                x = d3.event.sourceEvent.clientX;
-                y = d3.event.sourceEvent.clientY;
+                x = selection.event.sourceEvent.clientX;
+                y = selection.event.sourceEvent.clientY;
             }
 
             // Get mouse position within drawing area, used for rendering
-            var tx = d3.mouse(this)[0];
-            var ty = d3.mouse(this)[1];
+            var tx = selection.mouse(this)[0];
+            var ty = selection.mouse(this)[1];
 
             // Initialize the path or add the latest point to it
             if (tpath === "") {

--- a/src/lasso.js
+++ b/src/lasso.js
@@ -2,34 +2,42 @@ import * as selection from "d3-selection";
 import * as drag from "d3-drag";
 import classifyPoint from "robust-point-in-polygon";
 
-export default function() {
-
-    var items =[],
+export default function () {
+    var items = [],
         closePathDistance = 75,
+        synthetic = false,
         closePathSelect = true,
         isPathClosed = false,
         hoverSelect = true,
         targetArea,
-        on = {start:function(){}, draw: function(){}, end: function(){}};
+        on = {
+            start: function () { },
+            draw: function () { },
+            end: function () { },
+            clear: function (dyn_path, close_path, origin_node) {
+                dyn_path.attr("d", null);
+                close_path.attr("d", null);
+                origin_node.attr("display", "none");
+            }
+        };
 
     // Function to execute on call
     function lasso(_this) {
-
         // add a new group for the lasso
         var g = _this.append("g")
-            .attr("class","lasso");
-        
+            .attr("class", "lasso");
+
         // add the drawn path for the lasso
         var dyn_path = g.append("path")
-            .attr("class","drawn");
-        
+            .attr("class", "drawn");
+
         // add a closed path
         var close_path = g.append("path")
-            .attr("class","loop_close");
-        
+            .attr("class", "loop_close");
+
         // add an origin node
         var origin_node = g.append("circle")
-            .attr("class","origin");
+            .attr("class", "origin");
 
         // The transformed lasso path for rendering
         var tpath;
@@ -43,11 +51,11 @@ export default function() {
         // Store off coordinates drawn
         var drawnCoords;
 
-         // Apply drag behaviors
+        // Apply drag behaviors
         var dragAction = drag.drag()
-            .on("start",dragstart)
-            .on("drag",dragmove)
-            .on("end",dragend);
+            .on("start", dragstart)
+            .on("drag", dragmove)
+            .on("end", dragend);
 
         // Call drag
         targetArea.call(dragAction);
@@ -58,23 +66,32 @@ export default function() {
 
             // Initialize paths
             tpath = "";
-            dyn_path.attr("d",null);
-            close_path.attr("d",null);
+            dyn_path.attr("d", null);
+            close_path.attr("d", null);
+            origin_node.attr("display", "none");
 
             // Set every item to have a false selection and reset their center point and counters
-            items.nodes().forEach(function(e) {            
+            lasso.nodes().forEach(function (e) {
                 e.__lasso.possible = false;
                 e.__lasso.selected = false;
                 e.__lasso.hoverSelect = false;
                 e.__lasso.loopSelect = false;
-                
-                var box = e.getBoundingClientRect();
-                e.__lasso.lassoPoint = [Math.round(box.left + box.width/2),Math.round(box.top + box.height/2)];
+
+                // if synthetic, return the point itself. Otherwise calculate it from DOM
+                if (synthetic) {
+                    e.__lasso.lassoPoint = [Math.round(e.x), Math.round(e.y)];
+                } else {
+                    var box = e.getBoundingClientRect();
+                    e.__lasso.lassoPoint = [
+                        Math.round(box.left + box.width / 2),
+                        Math.round(box.top + box.height / 2)
+                    ];
+                }
             });
 
-            // if hover is on, add hover function
-            if(hoverSelect) {
-                items.on("mouseover.lasso",function() {
+            // if hover is on and we are not in synthetic mode, add hover function
+            if (hoverSelect && !synthetic) {
+                items.on("mouseover.lasso", function () {
                     // if hovered, change lasso selection attribute to true
                     this.__lasso.hoverSelect = true;
                 });
@@ -86,64 +103,66 @@ export default function() {
 
         function dragmove() {
             // Get mouse position within body, used for calculations
-            var x,y;
-            if(selection.event.sourceEvent.type === "touchmove") {
-                x = selection.event.sourceEvent.touches[0].clientX;
-                y = selection.event.sourceEvent.touches[0].clientY;
+            var x, y;
+            if (d3.event.sourceEvent.type === "touchmove") {
+                x = d3.event.sourceEvent.touches[0].clientX;
+                y = d3.event.sourceEvent.touches[0].clientY;
+            } else {
+                x = d3.event.sourceEvent.clientX;
+                y = d3.event.sourceEvent.clientY;
             }
-            else {
-                x = selection.event.sourceEvent.clientX;
-                y = selection.event.sourceEvent.clientY;
-            }
-            
 
             // Get mouse position within drawing area, used for rendering
-            var tx = selection.mouse(this)[0];
-            var ty = selection.mouse(this)[1];
+            var tx = d3.mouse(this)[0];
+            var ty = d3.mouse(this)[1];
 
             // Initialize the path or add the latest point to it
-            if (tpath==="") {
+            if (tpath === "") {
                 tpath = tpath + "M " + tx + " " + ty;
-                origin = [x,y];
-                torigin = [tx,ty];
+                origin = [x, y];
+                torigin = [tx, ty];
                 // Draw origin node
                 origin_node
-                    .attr("cx",tx)
-                    .attr("cy",ty)
-                    .attr("r",7)
-                    .attr("display",null);
-            }
-            else {
+                    .attr("cx", tx)
+                    .attr("cy", ty)
+                    .attr("r", 7)
+                    .attr("display", null);
+            } else {
                 tpath = tpath + " L " + tx + " " + ty;
             }
 
-            drawnCoords.push([x,y]);
+            drawnCoords.push([x, y]);
 
             // Calculate the current distance from the lasso origin
-            var distance = Math.sqrt(Math.pow(x-origin[0],2)+Math.pow(y-origin[1],2));
+            var distance = Math.sqrt(
+                Math.pow(x - origin[0], 2) + Math.pow(y - origin[1], 2)
+            );
 
             // Set the closed path line
-            var close_draw_path = "M " + tx + " " + ty + " L " + torigin[0] + " " + torigin[1];
+            var close_draw_path =
+                "M " + tx + " " + ty + " L " + torigin[0] + " " + torigin[1];
 
             // Draw the lines
-            dyn_path.attr("d",tpath);
+            dyn_path.attr("d", tpath);
 
-            close_path.attr("d",close_draw_path);
+            close_path.attr("d", close_draw_path);
 
             // Check if the path is closed
-            isPathClosed = distance<=closePathDistance ? true : false;
+            isPathClosed = distance <= closePathDistance ? true : false;
 
             // If within the closed path distance parameter, show the closed path. otherwise, hide it
-            if(isPathClosed && closePathSelect) {
-                close_path.attr("display",null);
-            }
-            else {
-                close_path.attr("display","none");
+            if (isPathClosed && closePathSelect) {
+                close_path.attr("display", null);
+            } else {
+                close_path.attr("display", "none");
             }
 
-            items.nodes().forEach(function(n) {
-                n.__lasso.loopSelect = (isPathClosed && closePathSelect) ? (classifyPoint(drawnCoords,n.__lasso.lassoPoint) < 1) : false; 
-                n.__lasso.possible = n.__lasso.hoverSelect || n.__lasso.loopSelect; 
+            lasso.nodes().forEach(function (n) {
+                n.__lasso.loopSelect =
+                    isPathClosed && closePathSelect
+                        ? classifyPoint(drawnCoords, n.__lasso.lassoPoint) < 1
+                        : false;
+                n.__lasso.possible = n.__lasso.hoverSelect || n.__lasso.loopSelect;
             });
 
             on.draw();
@@ -151,17 +170,17 @@ export default function() {
 
         function dragend() {
             // Remove mouseover tagging function
-            items.on("mouseover.lasso",null);
+            if (hoverSelect && !synthetic) {
+                items.on("mouseover.lasso", null);
+            }
 
-            items.nodes().forEach(function(n) {
+            lasso.nodes().forEach(function (n) {
                 n.__lasso.selected = n.__lasso.possible;
                 n.__lasso.possible = false;
             });
 
-            // Clear lasso
-            dyn_path.attr("d",null);
-            close_path.attr("d",null);
-            origin_node.attr("display","none");
+            // Invoke clear lasso callback. By default this will clear the lasso shape
+            on.clear(dyn_path, close_path, origin_node);
 
             // Run user defined end function
             on.end();
@@ -169,94 +188,103 @@ export default function() {
     }
 
     // Set or get list of items for lasso to select
-    lasso.items  = function(_) {
+    lasso.items = function (_) {
         if (!arguments.length) return items;
         items = _;
-        var nodes = items.nodes();
-        nodes.forEach(function(n) {
+        var nodes = lasso.nodes();
+        nodes.forEach(function (n) {
             n.__lasso = {
-                "possible": false,
-                "selected": false
+                possible: false,
+                selected: false
             };
         });
         return lasso;
     };
 
     // Return possible items
-    lasso.possibleItems = function() {
-        return items.filter(function() {
-            return this.__lasso.possible;
+    lasso.possibleItems = function () {
+        return items.filter(function (item) {
+            return (this || item).__lasso.possible;
         });
-    }
+    };
 
     // Return selected items
-    lasso.selectedItems = function() {
-        return items.filter(function() {
-            return this.__lasso.selected;
+    lasso.selectedItems = function () {
+        return items.filter(function (item) {
+            return (this || item).__lasso.selected;
         });
-    }
+    };
 
     // Return not possible items
-    lasso.notPossibleItems = function() {
-        return items.filter(function() {
-            return !this.__lasso.possible;
+    lasso.notPossibleItems = function () {
+        return items.filter(function (item) {
+            return !(this || item).__lasso.possible;
         });
-    }
+    };
 
     // Return not selected items
-    lasso.notSelectedItems = function() {
-        return items.filter(function() {
-            return !this.__lasso.selected;
+    lasso.notSelectedItems = function () {
+        return items.filter(function (item) {
+            return !(this || item).__lasso.selected;
         });
-    }
+    };
 
     // Distance required before path auto closes loop
-    lasso.closePathDistance  = function(_) {
+    lasso.closePathDistance = function (_) {
         if (!arguments.length) return closePathDistance;
         closePathDistance = _;
         return lasso;
     };
 
+    // whether the events are DOM nodes or not
+    lasso.synthetic = function (_) {
+        if (!arguments.length) return synthetic;
+        synthetic = _;
+        return lasso;
+    };
+
     // Option to loop select or not
-    lasso.closePathSelect = function(_) {
+    lasso.closePathSelect = function (_) {
         if (!arguments.length) return closePathSelect;
-        closePathSelect = _===true ? true : false;
+        closePathSelect = _ === true ? true : false;
         return lasso;
     };
 
     // Not sure what this is for
-    lasso.isPathClosed = function(_) {
+    lasso.isPathClosed = function (_) {
         if (!arguments.length) return isPathClosed;
-        isPathClosed = _===true ? true : false;
+        isPathClosed = _ === true ? true : false;
         return lasso;
     };
 
     // Option to select on hover or not
-    lasso.hoverSelect = function(_) {
+    lasso.hoverSelect = function (_) {
         if (!arguments.length) return hoverSelect;
-        hoverSelect = _===true ? true : false;
+        hoverSelect = _ === true ? true : false;
         return lasso;
     };
 
     // Events
-    lasso.on = function(type,_) {
-        if(!arguments.length) return on;
-        if(arguments.length===1) return on[type];
-        var types = ["start","draw","end"];
-        if(types.indexOf(type)>-1) {
+    lasso.on = function (type, _) {
+        if (!arguments.length) return on;
+        if (arguments.length === 1) return on[type];
+        var types = ["start", "draw", "end", "clear"];
+        if (types.indexOf(type) > -1) {
             on[type] = _;
         }
         return lasso;
     };
 
     // Area where lasso can be triggered from
-    lasso.targetArea = function(_) {
-        if(!arguments.length) return targetArea;
+    lasso.targetArea = function (_) {
+        if (!arguments.length) return targetArea;
         targetArea = _;
         return lasso;
-    }
+    };
 
+    lasso.nodes = function () {
+        return synthetic ? items : items.nodes();
+    };
 
-    
     return lasso;
 };


### PR DESCRIPTION
DEMO here: https://stackblitz.com/edit/lasso-synthetic?file=index.js

The vanilla lasso library has an expectation on nodes being present in the DOM. This PR provides a way to switch mode to `synthetic`, where no DOM nodes are needed to enabling lasso.
This is particularly needed when rendering an abstraction of a scatter plot that might contains tens of thousands of events (e.g. density map). Having to render so many DOM nodes just to enabling lasso has a significant performance impact. 

This will allow the user to create an object structure that will mirror the lasso-able nodes without needing to render them.