### PR TITLE
Changes to be compatible with d3 v6.x API 

### DIFF
--- a/src/lasso.js
+++ b/src/lasso.js
@@ -2,49 +2,49 @@ import * as selection from "d3-selection";
 import * as drag from "d3-drag";
 import classifyPoint from "robust-point-in-polygon";
 
-export default function() {
+export default function lasso() {
 
-    var items =[],
+    let items =[],
         closePathDistance = 75,
         closePathSelect = true,
         isPathClosed = false,
         hoverSelect = true,
         targetArea,
-        on = {start:function(){}, draw: function(){}, end: function(){}};
+        on = {start: function(){}, draw: function(){}, end: function(){}};
 
     // Function to execute on call
     function lasso(_this) {
 
         // add a new group for the lasso
-        var g = _this.append("g")
+        let g = _this.append("g")
             .attr("class","lasso");
-        
+
         // add the drawn path for the lasso
-        var dyn_path = g.append("path")
+        let dyn_path = g.append("path")
             .attr("class","drawn");
-        
+
         // add a closed path
-        var close_path = g.append("path")
+        let close_path = g.append("path")
             .attr("class","loop_close");
-        
+
         // add an origin node
-        var origin_node = g.append("circle")
+        let origin_node = g.append("circle")
             .attr("class","origin");
 
         // The transformed lasso path for rendering
-        var tpath;
+        let tpath;
 
         // The lasso origin for calculations
-        var origin;
+        let origin;
 
         // The transformed lasso origin for rendering
-        var torigin;
+        let torigin;
 
         // Store off coordinates drawn
-        var drawnCoords;
+        let drawnCoords;
 
          // Apply drag behaviors
-        var dragAction = drag.drag()
+        let dragAction = drag.drag()
             .on("start",dragstart)
             .on("drag",dragmove)
             .on("end",dragend);
@@ -62,13 +62,13 @@ export default function() {
             close_path.attr("d",null);
 
             // Set every item to have a false selection and reset their center point and counters
-            items.nodes().forEach(function(e) {            
+            items.nodes().forEach(function(e) {
                 e.__lasso.possible = false;
                 e.__lasso.selected = false;
                 e.__lasso.hoverSelect = false;
                 e.__lasso.loopSelect = false;
-                
-                var box = e.getBoundingClientRect();
+
+                let box = e.getBoundingClientRect();
                 e.__lasso.lassoPoint = [Math.round(box.left + box.width/2),Math.round(box.top + box.height/2)];
             });
 
@@ -84,22 +84,22 @@ export default function() {
             on.start();
         }
 
-        function dragmove() {
+        function dragmove(event) {
             // Get mouse position within body, used for calculations
-            var x,y;
-            if(selection.event.sourceEvent.type === "touchmove") {
-                x = selection.event.sourceEvent.touches[0].clientX;
-                y = selection.event.sourceEvent.touches[0].clientY;
+            let x,y;
+            if(event.sourceEvent.type === "touchmove") {
+                x = event.sourceEvent.touches[0].clientX;
+                y = event.sourceEvent.touches[0].clientY;
             }
             else {
-                x = selection.event.sourceEvent.clientX;
-                y = selection.event.sourceEvent.clientY;
+                x = event.sourceEvent.clientX;
+                y = event.sourceEvent.clientY;
             }
-            
+
 
             // Get mouse position within drawing area, used for rendering
-            var tx = selection.mouse(this)[0];
-            var ty = selection.mouse(this)[1];
+            let tx = selection.pointer(event, this)[0];
+            let ty = selection.pointer(event, this)[1];
 
             // Initialize the path or add the latest point to it
             if (tpath==="") {
@@ -110,7 +110,7 @@ export default function() {
                 origin_node
                     .attr("cx",tx)
                     .attr("cy",ty)
-                    .attr("r",7)
+                    .attr("r",4)
                     .attr("display",null);
             }
             else {
@@ -120,10 +120,10 @@ export default function() {
             drawnCoords.push([x,y]);
 
             // Calculate the current distance from the lasso origin
-            var distance = Math.sqrt(Math.pow(x-origin[0],2)+Math.pow(y-origin[1],2));
+            let distance = Math.sqrt(Math.pow(x-origin[0],2)+Math.pow(y-origin[1],2));
 
             // Set the closed path line
-            var close_draw_path = "M " + tx + " " + ty + " L " + torigin[0] + " " + torigin[1];
+            let close_draw_path = "M " + tx + " " + ty + " L " + torigin[0] + " " + torigin[1];
 
             // Draw the lines
             dyn_path.attr("d",tpath);
@@ -142,8 +142,8 @@ export default function() {
             }
 
             items.nodes().forEach(function(n) {
-                n.__lasso.loopSelect = (isPathClosed && closePathSelect) ? (classifyPoint(drawnCoords,n.__lasso.lassoPoint) < 1) : false; 
-                n.__lasso.possible = n.__lasso.hoverSelect || n.__lasso.loopSelect; 
+                n.__lasso.loopSelect = (isPathClosed && closePathSelect) ? (classifyPoint(drawnCoords,n.__lasso.lassoPoint) < 1) : false;
+                n.__lasso.possible = n.__lasso.hoverSelect || n.__lasso.loopSelect;
             });
 
             on.draw();
@@ -172,7 +172,7 @@ export default function() {
     lasso.items  = function(_) {
         if (!arguments.length) return items;
         items = _;
-        var nodes = items.nodes();
+        let nodes = items.nodes();
         nodes.forEach(function(n) {
             n.__lasso = {
                 "possible": false,
@@ -242,7 +242,7 @@ export default function() {
     lasso.on = function(type,_) {
         if(!arguments.length) return on;
         if(arguments.length===1) return on[type];
-        var types = ["start","draw","end"];
+        let types = ["start","draw","end"];
         if(types.indexOf(type)>-1) {
             on[type] = _;
         }
@@ -257,6 +257,6 @@ export default function() {
     }
 
 
-    
+
     return lasso;
 };


### PR DESCRIPTION
also replaces `var` with ES6 `let`; trivial formatting, etc.
